### PR TITLE
Unique naming of layers, etc. & other minor naming fixes

### DIFF
--- a/src/LayerEditor/ui/data/le_serializer.py
+++ b/src/LayerEditor/ui/data/le_serializer.py
@@ -24,7 +24,7 @@ class LESerializer():
         cfg.diagram = None
 
     def _get_first_geometry(self):
-        lname = "Layer 1"
+        lname = "Layer_1"
         gf = GeometryFactory()
         gf.set_default()
 

--- a/src/LayerEditor/ui/dialogs/layers/add_fracture.py
+++ b/src/LayerEditor/ui/dialogs/layers/add_fracture.py
@@ -4,6 +4,7 @@ Dialog for adding fracture to interface.
 
 import PyQt5.QtWidgets as QtWidgets
 from leconfig import cfg
+import PyQt5.QtGui as QtGui
 
 class AddFractureDlg(QtWidgets.QDialog):
 
@@ -12,13 +13,41 @@ class AddFractureDlg(QtWidgets.QDialog):
         self.setWindowTitle("Add Fracture")
 
         grid = QtWidgets.QGridLayout(self)
-        
+
+        def check_unique(foo):
+            unique_name = True
+            for _, fracture in cfg.diagram.regions.layers.items():
+                if foo == fracture:
+                    unique_name = False
+            if unique_name:
+                self.image.setPixmap(
+                    QtGui.QIcon.fromTheme("emblem-default").pixmap(self.fracture_name.sizeHint().height())
+                )
+                self.image.setToolTip('Fracture name is unique, everything is fine.')
+                self._tranform_button.setEnabled(True)
+            else:
+                self.image.setPixmap(
+                    QtGui.QIcon.fromTheme("emblem-important").pixmap(self.fracture_name.sizeHint().height())
+                )
+                self.image.setToolTip('Fracture name is not unique!')
+                self._tranform_button.setEnabled(False)
+
         d_fracture_name = QtWidgets.QLabel("Fracture Name:", self)
         self.fracture_name = QtWidgets.QLineEdit()
-        self.fracture_name.setText("Fracture_" + str(len(cfg.diagram.regions.layers)))
+        self.fracture_name.setText("Fracture_" + str(len(cfg.diagram.regions.layers)+1))
+        self.fracture_name.textChanged.connect(check_unique)
+
+        self.image = QtWidgets.QLabel(self)
+        self.image.setMinimumWidth(self.fracture_name.sizeHint().height())
+        self.image.setPixmap(QtGui.QIcon.fromTheme("emblem-default").pixmap(self.fracture_name.sizeHint().height()))
+        self.image.setToolTip('Fracture name is unique, everything is fine.')
+
         grid.addWidget(d_fracture_name, 0, 0)
         grid.addWidget(self.fracture_name, 0, 1)
-        
+        grid.addWidget(self.image, 0, 2)
+
+
+
         next_row = 1 
         self.fracture_position = None
         if  fracture_positions is not None:

--- a/src/LayerEditor/ui/dialogs/layers/add_fracture.py
+++ b/src/LayerEditor/ui/dialogs/layers/add_fracture.py
@@ -14,28 +14,11 @@ class AddFractureDlg(QtWidgets.QDialog):
 
         grid = QtWidgets.QGridLayout(self)
 
-        def check_unique(foo):
-            unique_name = True
-            for _, fracture in cfg.diagram.regions.layers.items():
-                if foo == fracture:
-                    unique_name = False
-            if unique_name:
-                self.image.setPixmap(
-                    QtGui.QIcon.fromTheme("emblem-default").pixmap(self.fracture_name.sizeHint().height())
-                )
-                self.image.setToolTip('Fracture name is unique, everything is fine.')
-                self._tranform_button.setEnabled(True)
-            else:
-                self.image.setPixmap(
-                    QtGui.QIcon.fromTheme("emblem-important").pixmap(self.fracture_name.sizeHint().height())
-                )
-                self.image.setToolTip('Fracture name is not unique!')
-                self._tranform_button.setEnabled(False)
-
         d_fracture_name = QtWidgets.QLabel("Fracture Name:", self)
         self.fracture_name = QtWidgets.QLineEdit()
-        self.fracture_name.setText("Fracture_" + str(len(cfg.diagram.regions.layers)+1))
-        self.fracture_name.textChanged.connect(check_unique)
+        self.have_default_name = True
+        self.set_default_name()
+        self.fracture_name.textChanged.connect(self.frac_name_changed)
 
         self.image = QtWidgets.QLabel(self)
         self.image.setMinimumWidth(self.fracture_name.sizeHint().height())
@@ -46,11 +29,9 @@ class AddFractureDlg(QtWidgets.QDialog):
         grid.addWidget(self.fracture_name, 0, 1)
         grid.addWidget(self.image, 0, 2)
 
-
-
         next_row = 1 
         self.fracture_position = None
-        if  fracture_positions is not None:
+        if fracture_positions is not None:
             d_fracture_position = QtWidgets.QLabel("Fracture position:", self)
             self.fracture_position = QtWidgets.QComboBox()
             for description, value in fracture_positions.items():
@@ -71,3 +52,38 @@ class AddFractureDlg(QtWidgets.QDialog):
 
         grid.addWidget(button_box, next_row, 1)
         self.setLayout(grid)
+
+    @classmethod
+    def is_unique_frac_name(self, name):
+        """ Return False in the case of colision with an existing region name."""
+        for _, fracture in cfg.diagram.regions.layers.items():
+            if name == fracture:
+                return False
+        return True
+
+    def frac_name_changed(self, name):
+        """ Called when Region Line Edit is changed."""
+        self.have_default_name = False
+        if self.is_unique_frac_name(name):
+            self.image.setPixmap(
+                QtGui.QIcon.fromTheme("emblem-default").pixmap(self.fracture_name.sizeHint().height())
+            )
+            self.image.setToolTip('Unique name is OK.')
+            self._tranform_button.setEnabled(True)
+        else:
+            self.image.setPixmap(
+                QtGui.QIcon.fromTheme("emblem-important").pixmap(self.fracture_name.sizeHint().height())
+            )
+            self.image.setToolTip('Name is not unique!')
+            self._tranform_button.setEnabled(False)
+
+    def set_default_name(self):
+        """ Set default name if it seems to be default name. """
+        if self.have_default_name:
+            frac_id = 0
+            name = cfg.diagram.regions.layers[0]
+            while not self.is_unique_frac_name(name):
+                frac_id += 1
+                name = "Fracture_" + str(frac_id)
+            self.fracture_name.setText(name)
+            self.have_default_name = True

--- a/src/LayerEditor/ui/dialogs/layers/add_fracture.py
+++ b/src/LayerEditor/ui/dialogs/layers/add_fracture.py
@@ -15,7 +15,7 @@ class AddFractureDlg(QtWidgets.QDialog):
         
         d_fracture_name = QtWidgets.QLabel("Fracture Name:", self)
         self.fracture_name = QtWidgets.QLineEdit()
-        self.fracture_name.setText("Fracture " + str(len(cfg.diagram.regions.layers)))
+        self.fracture_name.setText("Fracture_" + str(len(cfg.diagram.regions.layers)))
         grid.addWidget(d_fracture_name, 0, 0)
         grid.addWidget(self.fracture_name, 0, 1)
         

--- a/src/LayerEditor/ui/dialogs/layers/add_fracture.py
+++ b/src/LayerEditor/ui/dialogs/layers/add_fracture.py
@@ -3,6 +3,7 @@ Dialog for adding fracture to interface.
 """
 
 import PyQt5.QtWidgets as QtWidgets
+from leconfig import cfg
 
 class AddFractureDlg(QtWidgets.QDialog):
 
@@ -14,7 +15,7 @@ class AddFractureDlg(QtWidgets.QDialog):
         
         d_fracture_name = QtWidgets.QLabel("Fracture Name:", self)
         self.fracture_name = QtWidgets.QLineEdit()
-        self.fracture_name.setText("New Fracture")
+        self.fracture_name.setText("Fracture " + str(len(cfg.diagram.regions.layers)))
         grid.addWidget(d_fracture_name, 0, 0)
         grid.addWidget(self.fracture_name, 0, 1)
         

--- a/src/LayerEditor/ui/dialogs/layers/append_layer.py
+++ b/src/LayerEditor/ui/dialogs/layers/append_layer.py
@@ -18,12 +18,38 @@ class AppendLayerDlg(QtWidgets.QDialog):
         else:
             self.setWindowTitle("Append Layer")
         grid = QtWidgets.QGridLayout(self)
-        
+
+        def check_unique(foo):
+            unique_name = True
+            for _, layer in cfg.diagram.regions.layers.items():
+                if foo == layer:
+                    unique_name = False
+            if unique_name:
+                self.image.setPixmap(
+                    QtGui.QIcon.fromTheme("emblem-default").pixmap(self.layer_name.sizeHint().height())
+                )
+                self.image.setToolTip('Layer name is unique, everything is fine.')
+                self._tranform_button.setEnabled(True)
+            else:
+                self.image.setPixmap(
+                    QtGui.QIcon.fromTheme("emblem-important").pixmap(self.layer_name.sizeHint().height())
+                )
+                self.image.setToolTip('Layer name is not unique!')
+                self._tranform_button.setEnabled(False)
+
         d_layer_name = QtWidgets.QLabel("Layer Name:", self)
         self.layer_name = QtWidgets.QLineEdit()
         self.layer_name.setText("Layer_"+str(len(cfg.diagram.regions.layers)+1))
+        self.layer_name.textChanged.connect(check_unique)
+
+        self.image = QtWidgets.QLabel(self)
+        self.image.setMinimumWidth(self.layer_name.sizeHint().height())
+        self.image.setPixmap(QtGui.QIcon.fromTheme("emblem-default").pixmap(self.layer_name.sizeHint().height()))
+        self.image.setToolTip('Layer name is unique, everything is fine.')
+
         grid.addWidget(d_layer_name, 0, 0)
         grid.addWidget(self.layer_name, 0, 1)
+        grid.addWidget(self.image, 0, 2)
         
         d_surface = QtWidgets.QLabel("Bottom Interface Surface:", self)
         grid.addWidget(d_surface, 1, 0)

--- a/src/LayerEditor/ui/dialogs/layers/append_layer.py
+++ b/src/LayerEditor/ui/dialogs/layers/append_layer.py
@@ -5,6 +5,7 @@ Dialog for appending new layer to the end.
 import PyQt5.QtWidgets as QtWidgets
 import PyQt5.QtGui as QtGui
 from .layers_helpers import LayersHelpers
+from leconfig import cfg
 
 class AppendLayerDlg(QtWidgets.QDialog):
 
@@ -13,14 +14,14 @@ class AppendLayerDlg(QtWidgets.QDialog):
         if add:
             self.setWindowTitle("Add Layer to Shadow Block")
         elif prepend:
-            self.setWindowTitle("Add Layer")
-        else:
             self.setWindowTitle("Prepend Layer")
+        else:
+            self.setWindowTitle("Append Layer")
         grid = QtWidgets.QGridLayout(self)
         
         d_layer_name = QtWidgets.QLabel("Layer Name:", self)
         self.layer_name = QtWidgets.QLineEdit()
-        self.layer_name.setText("New Layer")
+        self.layer_name.setText("Layer "+str(len(cfg.diagram.regions.layers)+1))
         grid.addWidget(d_layer_name, 0, 0)
         grid.addWidget(self.layer_name, 0, 1)
         

--- a/src/LayerEditor/ui/dialogs/layers/append_layer.py
+++ b/src/LayerEditor/ui/dialogs/layers/append_layer.py
@@ -21,7 +21,7 @@ class AppendLayerDlg(QtWidgets.QDialog):
         
         d_layer_name = QtWidgets.QLabel("Layer Name:", self)
         self.layer_name = QtWidgets.QLineEdit()
-        self.layer_name.setText("Layer "+str(len(cfg.diagram.regions.layers)+1))
+        self.layer_name.setText("Layer_"+str(len(cfg.diagram.regions.layers)+1))
         grid.addWidget(d_layer_name, 0, 0)
         grid.addWidget(self.layer_name, 0, 1)
         

--- a/src/LayerEditor/ui/dialogs/layers/append_layer.py
+++ b/src/LayerEditor/ui/dialogs/layers/append_layer.py
@@ -19,28 +19,11 @@ class AppendLayerDlg(QtWidgets.QDialog):
             self.setWindowTitle("Append Layer")
         grid = QtWidgets.QGridLayout(self)
 
-        def check_unique(foo):
-            unique_name = True
-            for _, layer in cfg.diagram.regions.layers.items():
-                if foo == layer:
-                    unique_name = False
-            if unique_name:
-                self.image.setPixmap(
-                    QtGui.QIcon.fromTheme("emblem-default").pixmap(self.layer_name.sizeHint().height())
-                )
-                self.image.setToolTip('Layer name is unique, everything is fine.')
-                self._tranform_button.setEnabled(True)
-            else:
-                self.image.setPixmap(
-                    QtGui.QIcon.fromTheme("emblem-important").pixmap(self.layer_name.sizeHint().height())
-                )
-                self.image.setToolTip('Layer name is not unique!')
-                self._tranform_button.setEnabled(False)
-
         d_layer_name = QtWidgets.QLabel("Layer Name:", self)
         self.layer_name = QtWidgets.QLineEdit()
-        self.layer_name.setText("Layer_"+str(len(cfg.diagram.regions.layers)+1))
-        self.layer_name.textChanged.connect(check_unique)
+        self.have_default_name = True
+        self.set_default_name()
+        self.layer_name.textChanged.connect(self.lay_name_changed)
 
         self.image = QtWidgets.QLabel(self)
         self.image.setMinimumWidth(self.layer_name.sizeHint().height())
@@ -84,6 +67,41 @@ class AppendLayerDlg(QtWidgets.QDialog):
 
         grid.addWidget(button_box, i, 3, 1, 3)
         self.setLayout(grid)
+
+    @classmethod
+    def is_unique_layer_name(self, lay_name):
+        """ Return False in the case of colision with an existing region name."""
+        for _, layer in cfg.diagram.regions.layers.items():
+            if lay_name == layer:
+                return False
+        return True
+
+    def lay_name_changed(self, name):
+        """ Called when Region Line Edit is changed."""
+        self.have_default_name = False
+        if self.is_unique_layer_name(name):
+            self.image.setPixmap(
+                QtGui.QIcon.fromTheme("emblem-default").pixmap(self.layer_name.sizeHint().height())
+            )
+            self.image.setToolTip('Unique name is OK.')
+            self._tranform_button.setEnabled(True)
+        else:
+            self.image.setPixmap(
+                QtGui.QIcon.fromTheme("emblem-important").pixmap(self.layer_name.sizeHint().height())
+            )
+            self.image.setToolTip('Name is not unique!')
+            self._tranform_button.setEnabled(False)
+
+    def set_default_name(self):
+        """ Set default name if it seems to be default name. """
+        if self.have_default_name:
+            lay_id = 0
+            name = cfg.diagram.regions.layers[0]
+            while not self.is_unique_layer_name(name):
+                lay_id += 1
+                name = "Layer_" + str(lay_id)
+            self.layer_name.setText(name)
+            self.have_default_name = True
 
     def accept(self):
         """

--- a/src/LayerEditor/ui/dialogs/layers/set_property.py
+++ b/src/LayerEditor/ui/dialogs/layers/set_property.py
@@ -14,7 +14,7 @@ class SetNameDlg(QtWidgets.QDialog):
 
         grid = QtWidgets.QGridLayout(self)
         
-        d_name = QtWidgets.QLabel("Layer {0} Name:".format(category), self)
+        d_name = QtWidgets.QLabel("{0} Name:".format(category), self)
         self.name = QtWidgets.QLineEdit()
         self.name.setText(value)
         grid.addWidget(d_name, 0, 0)

--- a/src/LayerEditor/ui/dialogs/layers/split_layer.py
+++ b/src/LayerEditor/ui/dialogs/layers/split_layer.py
@@ -5,6 +5,7 @@ Dialog for appending new layer to the end.
 import PyQt5.QtWidgets as QtWidgets
 import PyQt5.QtGui as QtGui
 from .layers_helpers import LayersHelpers
+from leconfig import cfg
 
 class SplitLayerDlg(QtWidgets.QDialog):
 
@@ -13,13 +14,39 @@ class SplitLayerDlg(QtWidgets.QDialog):
         self.setWindowTitle("Split Layer")
 
         grid = QtWidgets.QGridLayout(self)
-        
+
+        def check_unique(foo):
+            unique_name = True
+            for _, layer in cfg.diagram.regions.layers.items():
+                if foo == layer:
+                    unique_name = False
+            if unique_name:
+                self.image.setPixmap(
+                    QtGui.QIcon.fromTheme("emblem-default").pixmap(self.layer_name.sizeHint().height())
+                )
+                self.image.setToolTip('Layer name is unique, everything is fine.')
+                self._tranform_button.setEnabled(True)
+            else:
+                self.image.setPixmap(
+                    QtGui.QIcon.fromTheme("emblem-important").pixmap(self.layer_name.sizeHint().height())
+                )
+                self.image.setToolTip('Layer name is not unique!')
+                self._tranform_button.setEnabled(False)
+
         d_layer_name = QtWidgets.QLabel("Layer Name:", self)
         self.layer_name = QtWidgets.QLineEdit()
         self.layer_name.setToolTip("New Layer name (New layer is in the bottom)")
-        self.layer_name.setText("New layer")
+        self.layer_name.setText("Layer_" + str(len(cfg.diagram.regions.layers) + 1))
+        self.layer_name.textChanged.connect(check_unique)
+
+        self.image = QtWidgets.QLabel(self)
+        self.image.setMinimumWidth(self.layer_name.sizeHint().height())
+        self.image.setPixmap(QtGui.QIcon.fromTheme("emblem-default").pixmap(self.layer_name.sizeHint().height()))
+        self.image.setToolTip('Layer name is unique, everything is fine.')
+
         grid.addWidget(d_layer_name, 0, 0)
         grid.addWidget(self.layer_name, 0, 1)
+        grid.addWidget(self.image, 0, 2)
         
         d_split_type = QtWidgets.QLabel("Split Interface Type:", self)
         self.split_type = LayersHelpers.split_type_combo(copy_block)

--- a/src/LayerEditor/ui/dialogs/layers/split_layer.py
+++ b/src/LayerEditor/ui/dialogs/layers/split_layer.py
@@ -15,29 +15,12 @@ class SplitLayerDlg(QtWidgets.QDialog):
 
         grid = QtWidgets.QGridLayout(self)
 
-        def check_unique(foo):
-            unique_name = True
-            for _, layer in cfg.diagram.regions.layers.items():
-                if foo == layer:
-                    unique_name = False
-            if unique_name:
-                self.image.setPixmap(
-                    QtGui.QIcon.fromTheme("emblem-default").pixmap(self.layer_name.sizeHint().height())
-                )
-                self.image.setToolTip('Layer name is unique, everything is fine.')
-                self._tranform_button.setEnabled(True)
-            else:
-                self.image.setPixmap(
-                    QtGui.QIcon.fromTheme("emblem-important").pixmap(self.layer_name.sizeHint().height())
-                )
-                self.image.setToolTip('Layer name is not unique!')
-                self._tranform_button.setEnabled(False)
-
         d_layer_name = QtWidgets.QLabel("Layer Name:", self)
         self.layer_name = QtWidgets.QLineEdit()
         self.layer_name.setToolTip("New Layer name (New layer is in the bottom)")
-        self.layer_name.setText("Layer_" + str(len(cfg.diagram.regions.layers) + 1))
-        self.layer_name.textChanged.connect(check_unique)
+        self.have_default_name = True
+        self.set_default_name()
+        self.layer_name.textChanged.connect(self.lay_name_changed)
 
         self.image = QtWidgets.QLabel(self)
         self.image.setMinimumWidth(self.layer_name.sizeHint().height())
@@ -75,6 +58,41 @@ class SplitLayerDlg(QtWidgets.QDialog):
 
         grid.addWidget(button_box, i, 1, 1, 2)
         self.setLayout(grid)
+
+    @classmethod
+    def is_unique_layer_name(self, lay_name):
+        """ Return False in the case of colision with an existing region name."""
+        for _, layer in cfg.diagram.regions.layers.items():
+            if lay_name == layer:
+                return False
+        return True
+
+    def lay_name_changed(self, name):
+        """ Called when Region Line Edit is changed."""
+        self.have_default_name = False
+        if self.is_unique_layer_name(name):
+            self.image.setPixmap(
+                QtGui.QIcon.fromTheme("emblem-default").pixmap(self.layer_name.sizeHint().height())
+            )
+            self.image.setToolTip('Unique name is OK.')
+            self._tranform_button.setEnabled(True)
+        else:
+            self.image.setPixmap(
+                QtGui.QIcon.fromTheme("emblem-important").pixmap(self.layer_name.sizeHint().height())
+            )
+            self.image.setToolTip('Name is not unique!')
+            self._tranform_button.setEnabled(False)
+
+    def set_default_name(self):
+        """ Set default name if it seems to be default name. """
+        if self.have_default_name:
+            lay_id = 0
+            name = cfg.diagram.regions.layers[0]
+            while not self.is_unique_layer_name(name):
+                lay_id += 1
+                name = "Layer_" + str(lay_id)
+            self.layer_name.setText(name)
+            self.have_default_name = True
 
     def accept(self):
         """

--- a/src/LayerEditor/ui/dialogs/regions/add_region.py
+++ b/src/LayerEditor/ui/dialogs/regions/add_region.py
@@ -139,7 +139,7 @@ class AddRegionDlg(QtWidgets.QDialog):
         return cls.BACKGROUND_COLORS[i % len(cls.BACKGROUND_COLORS)]
 
 
-    def  set_default_name(self, dim):
+    def set_default_name(self, dim):
         """ Set default name if it seems to be default name. """
         if self.have_default_name:
             dim_to_regtype = ["point_", "well_", "fracture_", "bulk_"]

--- a/src/LayerEditor/ui/dialogs/regions/add_region.py
+++ b/src/LayerEditor/ui/dialogs/regions/add_region.py
@@ -63,10 +63,11 @@ class AddRegionDlg(QtWidgets.QDialog):
         self.setWindowTitle("Add Region")
 
         grid = QtWidgets.QGridLayout(self)
-        
+
+        on_creation_dim = 3
         d_region_name = QtWidgets.QLabel("Region Name:", self)
         self.region_name = QtWidgets.QLineEdit()
-        self.region_name.setText("New Region")
+        self.region_name.setText("("+str(on_creation_dim)+"D) Region "+str(len(cfg.diagram.regions.regions)))
         grid.addWidget(d_region_name, 0, 0)
         grid.addWidget(self.region_name, 0, 1)
         
@@ -76,9 +77,15 @@ class AddRegionDlg(QtWidgets.QDialog):
         self.region_dim.addItem(self.REGION_DESCRIPTION[RegionDim.well], RegionDim.well)
         self.region_dim.addItem(self.REGION_DESCRIPTION[RegionDim.fracture], RegionDim.fracture)
         self.region_dim.addItem(self.REGION_DESCRIPTION[RegionDim.bulk], RegionDim.bulk)
-        self.region_dim.setCurrentIndex(3) 
-        grid.addWidget(d_region_dim , 1, 0)
-        grid.addWidget(self.region_dim , 1, 1)
+        self.region_dim.setCurrentIndex(on_creation_dim)
+
+        def adjust_name(idx):
+            if self.region_name.text()[0:5] in ["(0D) ", "(1D) ", "(2D) ", "(3D) "]:
+                self.region_name.setText("("+str(idx)+"D) "+self.region_name.text()[5:])
+
+        self.region_dim.currentIndexChanged[int].connect(adjust_name)
+        grid.addWidget(d_region_dim, 1, 0)
+        grid.addWidget(self.region_dim, 1, 1)
 
         self._tranform_button = QtWidgets.QPushButton("Add", self)
         self._tranform_button.clicked.connect(self.accept)
@@ -96,7 +103,7 @@ class AddRegionDlg(QtWidgets.QDialog):
     def get_some_color(cls, i):
         """Return firs collor accoding to index"""
         return cls.BACKGROUND_COLORS[i % len(cls.BACKGROUND_COLORS)]
-        
+
     def accept(self):
         """
         Accepts the form if region data is valid.

--- a/src/LayerEditor/ui/dialogs/regions/add_region.py
+++ b/src/LayerEditor/ui/dialogs/regions/add_region.py
@@ -67,7 +67,7 @@ class AddRegionDlg(QtWidgets.QDialog):
         on_creation_dim = 3
         d_region_name = QtWidgets.QLabel("Region Name:", self)
         self.region_name = QtWidgets.QLineEdit()
-        self.region_name.setText("("+str(on_creation_dim)+"D) Region "+str(len(cfg.diagram.regions.regions)))
+        self.region_name.setText(str(on_creation_dim)+"D_Region_"+str(len(cfg.diagram.regions.regions)))
         grid.addWidget(d_region_name, 0, 0)
         grid.addWidget(self.region_name, 0, 1)
         
@@ -80,8 +80,8 @@ class AddRegionDlg(QtWidgets.QDialog):
         self.region_dim.setCurrentIndex(on_creation_dim)
 
         def adjust_name(idx):
-            if self.region_name.text()[0:5] in ["(0D) ", "(1D) ", "(2D) ", "(3D) "]:
-                self.region_name.setText("("+str(idx)+"D) "+self.region_name.text()[5:])
+            if self.region_name.text()[0:3] in ["0D_", "1D_", "2D_", "3D_"]:
+                self.region_name.setText(str(idx)+"D_"+self.region_name.text()[3:])
 
         self.region_dim.currentIndexChanged[int].connect(adjust_name)
         grid.addWidget(d_region_dim, 1, 0)

--- a/src/LayerEditor/ui/dialogs/regions/add_region.py
+++ b/src/LayerEditor/ui/dialogs/regions/add_region.py
@@ -64,20 +64,49 @@ class AddRegionDlg(QtWidgets.QDialog):
 
         grid = QtWidgets.QGridLayout(self)
 
-        on_creation_dim = 3
-        d_region_name = QtWidgets.QLabel("Region Name:", self)
-        self.region_name = QtWidgets.QLineEdit()
-        self.region_name.setText(str(on_creation_dim)+"D_Region_"+str(len(cfg.diagram.regions.regions)))
-        grid.addWidget(d_region_name, 0, 0)
-        grid.addWidget(self.region_name, 0, 1)
-        
         d_region_dim = QtWidgets.QLabel("Region Dimension:", self)
-        self.region_dim = QtWidgets.QComboBox()            
+        self.region_dim = QtWidgets.QComboBox()
         self.region_dim.addItem(self.REGION_DESCRIPTION[RegionDim.point], RegionDim.point)
         self.region_dim.addItem(self.REGION_DESCRIPTION[RegionDim.well], RegionDim.well)
         self.region_dim.addItem(self.REGION_DESCRIPTION[RegionDim.fracture], RegionDim.fracture)
         self.region_dim.addItem(self.REGION_DESCRIPTION[RegionDim.bulk], RegionDim.bulk)
-        self.region_dim.setCurrentIndex(on_creation_dim)
+        # TODO: change the default value according to the maximal dimension of selected elements in the viewport area
+        self.region_dim.setCurrentIndex(self.region_dim.count()-1)
+
+        def check_unique(foo):
+            unique_name = True
+            for region in cfg.diagram.regions.regions:
+                if foo == region.name:
+                    unique_name = False
+            if unique_name:
+                self.image.setPixmap(
+                    QtGui.QIcon.fromTheme("emblem-default").pixmap(self.region_name.sizeHint().height())
+                )
+                self.image.setToolTip('Region name is unique, everything is fine.')
+                self._tranform_button.setEnabled(True)
+            else:
+                self.image.setPixmap(
+                    QtGui.QIcon.fromTheme("emblem-important").pixmap(self.region_name.sizeHint().height())
+                )
+                self.image.setToolTip('Region name is not unique!')
+                self._tranform_button.setEnabled(False)
+
+
+        d_region_name = QtWidgets.QLabel("Region Name:", self)
+        self.region_name = QtWidgets.QLineEdit()
+        self.region_name.setText(str(self.region_dim.currentIndex())+"D_Region_"+str(len(cfg.diagram.regions.regions)))
+        self.region_name.textChanged.connect(check_unique)
+
+        self.image = QtWidgets.QLabel(self)
+        self.image.setMinimumWidth(self.region_name.sizeHint().height())
+        self.image.setPixmap(QtGui.QIcon.fromTheme("emblem-default").pixmap(self.region_name.sizeHint().height()))
+        self.image.setToolTip('Region name is unique, everything is fine.')
+
+        grid.addWidget(d_region_name, 0, 0)
+        grid.addWidget(self.region_name, 0, 1)
+        grid.addWidget(self.image, 0, 2)
+
+
 
         def adjust_name(idx):
             if self.region_name.text()[0:3] in ["0D_", "1D_", "2D_", "3D_"]:
@@ -85,7 +114,7 @@ class AddRegionDlg(QtWidgets.QDialog):
 
         self.region_dim.currentIndexChanged[int].connect(adjust_name)
         grid.addWidget(d_region_dim, 1, 0)
-        grid.addWidget(self.region_dim, 1, 1)
+        grid.addWidget(self.region_dim, 1, 1, 1, 2)
 
         self._tranform_button = QtWidgets.QPushButton("Add", self)
         self._tranform_button.clicked.connect(self.accept)

--- a/src/LayerEditor/ui/panels/regions.py
+++ b/src/LayerEditor/ui/panels/regions.py
@@ -293,7 +293,7 @@ class Regions(QtWidgets.QToolBox):
             self._add_disply_region(region)
             layer_id = self.layers_id[self.currentIndex()]
             self._set_box_title(self.currentIndex(), layer_id)
-            
+
     def _name_set(self, layer_id):
         """Name is changed"""
         if self.update_region_data:


### PR DESCRIPTION
general minor fixes
layers: 
  prepend<->append naming issue in dialogue -> simple switch
  rename duplicit 'Layer' -> text `a la 'Layer Layer Name', 'Layer Fracture Name', etc.
unique names
regions: automatic naming of new regions with dimension adjusts on dropdown change
layers: unique Layer names and fracture names

added TODO in gdocs:
  cfg.diagram.regions.layer_topology seems broken when prepend layer is used
    -> separate layer and fracture numbering