### PR TITLE
MM regions panel updates upon minor change

### DIFF
--- a/src/LayerEditor/ui/data/diagram_structures.py
+++ b/src/LayerEditor/ui/data/diagram_structures.py
@@ -444,7 +444,7 @@ class Diagram():
         return remapped_regions
                 
     def region_color_changed(self, region_idx):
-        """Region collor was changed"""
+        """Region color was changed"""
         for polygon in self.polygons:
             if self.regions.get_region_id(2, polygon.id)==region_idx:
                 polygon.object.update_color()

--- a/src/LayerEditor/ui/panels/regions.py
+++ b/src/LayerEditor/ui/panels/regions.py
@@ -441,6 +441,10 @@ class Regions(QtWidgets.QToolBox):
         region_id = self.regions[layer_id].currentData()
         data.set_region_not_used(region_id, self.notused[layer_id].isChecked(), 
             True, "Set region usage")
+        for l_id in self.layers:
+            if self.regions[l_id].currentData() == region_id:
+                self.notused[l_id].setChecked(self.notused[layer_id].isChecked())
+
 
     def _boundary_set(self, layer_id):
         """Region boundary property is changed"""
@@ -450,6 +454,9 @@ class Regions(QtWidgets.QToolBox):
         region_id = self.regions[layer_id].currentData()
         data.set_region_boundary(region_id, self.boundary[layer_id].isChecked(), 
             True, "Set region boundary")
+        for l_id in self.layers:
+            if self.regions[l_id].currentData() == region_id:
+                self.boundary[l_id].setChecked(self.boundary[layer_id].isChecked())
 
     def _mesh_step_set(self, layer_id):
         if self.update_region_data:
@@ -459,6 +466,9 @@ class Regions(QtWidgets.QToolBox):
         region_id = self.regions[layer_id].currentData()
         data.set_region_mesh_step(region_id, step_value,
             True, "Set region mesh step")
+        for l_id in self.layers:
+            if self.regions[l_id].currentData() == region_id:
+                self.mesh_step[l_id].setText("{:.1f}".format(step_value))
 
 
     def _layer_changed(self):


### PR DESCRIPTION
Problem:
Name/color change in region panel does not affect other tabs.
Solution:
Manual change by for cycle withing designated functions.

Upgrade suggestion:
unify within public function 'update_regions_panel' and call those designated functions for minor updates, while filtering necessary operations in the public one.
