### PR TITLE
Topology switch deletes all elements in diagram, calling region updat…

### DIFF
--- a/src/LayerEditor/ui/data/diagram_structures.py
+++ b/src/LayerEditor/ui/data/diagram_structures.py
@@ -187,10 +187,10 @@ class Line():
         """Set line region to default region"""
         return Diagram.regions.set_default(1, self.id, True, "Set Default Region")
 
-        
     def get_regions(self):
         """Return polygon regions"""
         return Diagram.regions.get_regions(1, self.id)
+
 
 class Polygon():
     """

--- a/src/LayerEditor/ui/mainwindow.py
+++ b/src/LayerEditor/ui/mainwindow.py
@@ -117,6 +117,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.layers.editInterfaceChanged.connect(self.refresh_curr_data)
         self.layers.topologyChanged.connect(self.set_topology)
         self.layers.refreshArea.connect(self._refresh_area)
+        self.layers.clearDiagramSelection.connect(self.clear_diagram_selection)
         self.regions.regionChanged.connect(self._region_changed)
         self.wg_surface_panel.show_grid.connect(self._show_grid)
         #self.surfaces.refreshArea.connect(self._refresh_area)
@@ -266,7 +267,11 @@ class MainWindow(QtWidgets.QMainWindow):
     def set_topology(self):
         """Current topology or its structure is changed"""
         self.regions.set_topology(cfg.diagram.topology_idx)
-        
+
+    def clear_diagram_selection(self):
+        """Selection has to be emptied"""
+        self.diagramScene.selection.deselect_selected()
+
     def _update_regions(self):
         """Update region panel, eventually set tab according to the selection in diagram"""
         regions = self.diagramScene.selection.get_selected_regions(cfg.diagram)

--- a/src/LayerEditor/ui/panels/layers.py
+++ b/src/LayerEditor/ui/panels/layers.py
@@ -22,7 +22,9 @@ class Layers(QtWidgets.QWidget):
     All regions function contains history operation without label and
     must be placed after first history operation with label.
     """
-    
+    clearDiagramSelection = QtCore.pyqtSignal()
+    """Signal is sent when selection needs to be cleared to prevent topology switch issues."""
+
     topologyChanged = QtCore.pyqtSignal()
     """Signal is sent when current selected topology or some 
     topology structure is changed."""
@@ -297,9 +299,10 @@ class Layers(QtWidgets.QWidget):
         cfg.layers.set_edited_interface(i, second, fracture)
         diagram_idx = cfg.layers.get_diagram_idx(i, second, fracture)
         old = cfg.set_curr_diagram(diagram_idx)
-        self.update() 
+        self.update()
+        self.clearDiagramSelection.emit() # different topology selection cannot correlate to the new one
         self.topologyChanged.emit() # first update regions      
-        self. editInterfaceChanged.emit(old, diagram_idx)        
+        self.editInterfaceChanged.emit(old, diagram_idx)
     
     def add_interface(self, i):
         """Split layer by new interface"""


### PR DESCRIPTION
resolve #241
get_regions function works one way with lower dimension dictionaries layer_region_1D, layer_region_0D
- those suggest that shape_id should be different for each topology (corresponds to various graphical objects as well)
- still problematic call on layer block switch with any of them selected - shape_id given to get_regions function is of the old topology, yet it doesnt exist in the new one anymore.

TODO:
- [ ] Cancel selection on layer block switch.
- [ ] Fix ids for layer_region_2D - ids from new layer blocks are duplicated in old ones (polygon addition called without copy label)