### PR TITLE
Help dialog in file menu.

### DIFF
--- a/src/LayerEditor/ui/dialogs/LE_help.py
+++ b/src/LayerEditor/ui/dialogs/LE_help.py
@@ -1,0 +1,54 @@
+"""
+Module contains help dialog.
+"""
+
+from gm_base.version import Version
+from PyQt5.QtWidgets import (QDialog, QLabel, QGridLayout)
+from PyQt5.QtCore import QUrl, Qt
+from PyQt5.QtGui import QDesktopServices, QFont
+
+__author__ = 'Martin Matusu'
+
+class LE_help_dialog(QDialog):
+    """Dialog for displaying help information for LE. Main element is the link to documentation."""
+
+    def __init__(self, parent, title='Layer Editor Help'):
+        """Initializes the class."""
+        super(LE_help_dialog, self).__init__(parent)
+
+        version = Version()
+        self.version = version.version
+
+        link_label = QLabel()
+        link_label.linkActivated.connect(self.link)
+        link_label.setAlignment(Qt.AlignCenter)
+        link_label.setText('<a href="https://docs.google.com/document/d/1DipuCU-Gb9uCIGuSuYZOUIPLzQaHstPOYMD7smHNcQw/">Geomop reference guide</a>')
+        link_label.setFont(QFont("monospace"))
+
+        main_layout = QGridLayout()
+        main_layout.addWidget(link_label, 0, 0)
+        self.setLayout(main_layout)
+
+        self.title = title + ' v.' + self.version
+        self.setWindowTitle(self.title)
+        self.setMinimumSize(300, 100)
+        self.setModal(True)
+
+    @staticmethod
+    def link(linkStr):
+        QDesktopServices.openUrl(QUrl(linkStr))
+
+
+if __name__ == '__main__':
+    def main():
+        """"Launches dialog."""
+        import sys
+        from PyQt5.QtWidgets import QApplication
+
+        app = QApplication(sys.argv)
+        dialog = LE_help_dialog(None)
+        dialog.show()
+        sys.exit(app.exec_())
+    main()
+
+

--- a/src/LayerEditor/ui/dialogs/__init__.py
+++ b/src/LayerEditor/ui/dialogs/__init__.py
@@ -1,0 +1,5 @@
+"""
+Module contains standardized Layer Ediotor specific dialogs.
+"""
+
+from .LE_help import LE_help_dialog

--- a/src/LayerEditor/ui/menus/file.py
+++ b/src/LayerEditor/ui/menus/file.py
@@ -4,6 +4,7 @@ from PyQt5.QtWidgets import QMenu, QAction, QActionGroup, qApp
 
 from LayerEditor.leconfig import cfg
 from gm_base.geomop_dialogs import GMAboutDialog
+from LayerEditor.ui.dialogs import LE_help_dialog
 
 
 class MainFileMenu(QMenu):
@@ -58,6 +59,11 @@ class MainFileMenu(QMenu):
         self._about_action.triggered.connect(self._on_about_action_clicked)
         self.addAction(self._about_action)
 
+        self._help_dialog = LE_help_dialog(parent)
+        self._help_action = QAction('Help', self)
+        self._help_action.triggered.connect(self._on_help_action_clicked)
+        self.addAction(self._help_action)
+
         self.addSeparator()
 
         self._exit_action = QAction('E&xit', self)
@@ -88,8 +94,13 @@ class MainFileMenu(QMenu):
     def _on_about_action_clicked(self):
         """Displays about dialog."""
         if not self._about_dialog.isVisible():
-            self._about_dialog.show()        
-            
+            self._about_dialog.show()
+
+    def _on_help_action_clicked(self):
+        """Displays help dialog."""
+        if not self._help_dialog.isVisible():
+            self._help_dialog.show()
+
     def _exit_clicked(self):
         """Performs actions before app is closed."""
         # prompt user to save changes (if any)


### PR DESCRIPTION
resolves #227 
Simple for now. Help window may be extended to show basic controls, so the user doesn't have to open the docs.
exact docs link should be made from version file link of the whole GeoMop package.

TODO:
 - [ ] Link on a versioning output location of documentation link

Signed-off-by: Martin Matusu <Martin.Matusu@tul.cz>