### PR TITLE
Mm outer envelope drag

### DIFF
--- a/src/LayerEditor/ui/panels/diagram.py
+++ b/src/LayerEditor/ui/panels/diagram.py
@@ -449,15 +449,13 @@ class Diagram(QtWidgets.QGraphicsScene):
             self._line_moving_counter += 1
             if self._line_moving_counter%3==0:
                 # point at old position
-                displacement = event.scenePos() - self._line_moving_old_pos
-                p1_data = cfg.diagram.po.decomposition.points[self._line_moving.line_data.p1.de_id]
-                p2_data = cfg.diagram.po.decomposition.points[self._line_moving.line_data.p2.de_id]
-                if cfg.diagram.po.decomposition.check_displacment(
-                        [p1_data, p2_data], np.array([displacement.x(), -displacement.y()])):
-                    if self._line_moving_counter == 3:
-                        self._line_moving.shift_line(event.scenePos()-self._line_moving_pos, ItemStates.moved)
-                    else:
-                        self._line_moving.shift_line(event.scenePos()-self._line_moving_pos)
+                if self._line_moving_counter == 3:
+                    self._line_moving.shift_line(event.scenePos() - self._line_moving_pos, ItemStates.moved)
+                else:
+                    self._line_moving.shift_line(event.scenePos() - self._line_moving_pos)
+                if not cfg.diagram.update_moving_points([self._line_moving.line_data.p1, self._line_moving.line_data.p2]):
+                    self._line_moving.shift_line(-event.scenePos() + self._line_moving_pos)
+                else:
                     self._line_moving_pos = event.scenePos()
             else:
                 self.cursorChanged.emit(event.scenePos().x(), event.scenePos().y())

--- a/src/LayerEditor/ui/panels/diagram.py
+++ b/src/LayerEditor/ui/panels/diagram.py
@@ -433,16 +433,16 @@ class Diagram(QtWidgets.QGraphicsScene):
         elif self._point_moving is not None:
             self._point_moving_counter += 1
             if self._point_moving_counter%3==0:
-                # displacement from old position
-                displacement = event.scenePos() - self._point_moving_old
                 # point at old position
                 point_data = cfg.diagram.po.decomposition.points[self._point_moving.point_data.de_id]
-                if cfg.diagram.po.decomposition.check_displacment(
-                        [point_data], np.array([displacement.x(), -displacement.y()])):
-                    if self._point_moving_counter == 3:
-                        self._point_moving.move_point(event.scenePos(), ItemStates.moved)
-                    else:
-                        self._point_moving.move_point(event.scenePos())
+                if self._point_moving_counter == 3:
+                    self._point_moving.move_point(event.scenePos(), ItemStates.moved)
+                else:
+                    self._point_moving.move_point(event.scenePos())
+                if not cfg.diagram.update_moving_points([self._point_moving.point_data]):
+                    self._point_moving.move_point(
+                        QtCore.QPointF(point_data.xy[0], -point_data.xy[1])
+                    )
             else:
                 self.cursorChanged.emit(event.scenePos().x(), event.scenePos().y())
         elif self._line_moving is not None:

--- a/src/gm_base/polygons/polygons.py
+++ b/src/gm_base/polygons/polygons.py
@@ -173,7 +173,6 @@ class PolygonDecomposition:
                 if (seg, side) not in moving_segs and (seg, 1 - side) not in moving_segs:
                         envelope.append(seg)
 
-
         for e_seg in envelope:
             # Check collision of points with envelope.
             for pt in points:

--- a/src/gm_base/polygons/polygons.py
+++ b/src/gm_base/polygons/polygons.py
@@ -163,12 +163,14 @@ class PolygonDecomposition:
 
         # Todo: For the outer wire of the moving segments, add parent and its holes to the envelope.
         # Outer wire is the maximal parent wire for the set of all wires connected to moving edges.
-        moving_wires = { poly.outer_wire for poly in changed_polygons}
+        boundary_wires = [poly.outer_wire for poly in changed_polygons]
+        for wire in boundary_wires:
+            for child in wire.childs:
+                boundary_wires.append(child)
         envelope=[]
-        for wire in moving_wires:
+        for wire in boundary_wires:
             for seg, side in wire.segments():
-                if (seg, side) not in moving_segs and \
-                    (seg, 1 - side) not in moving_segs:
+                if (seg, side) not in moving_segs and (seg, 1 - side) not in moving_segs:
                         envelope.append(seg)
 
 
@@ -539,7 +541,6 @@ class PolygonDecomposition:
             return (t0, t1)
         else:
             return (None, None)
-
 
     ################################
     # Serialization methods - should move into polygon_io


### PR DESCRIPTION
Children of outer_wires of moving polygons are now considered in the envelope as well.
The data layer is updated upon movement immediately, not after mouse release -> points can be moved within envelope without a problem at the concave hull.