### PR TITLE
Move line block refactor

### DIFF
--- a/src/LayerEditor/ui/data/diagram_structures.py
+++ b/src/LayerEditor/ui/data/diagram_structures.py
@@ -823,7 +823,7 @@ class Diagram():
         return None
         
     def find_line(self, p1_id, p2_id):
-        """Find line accoding points index"""
+        """Find line according to points index"""
         p1 = self.get_point_by_de_id(p1_id)
         p2 = self.get_point_by_de_id(p2_id)
         for line in p1.lines:
@@ -964,7 +964,7 @@ class Diagram():
     def join_line(self,p1, p2, label=None, id=None, not_history=False, copy=None):
         """Add line from point p1 to p2"""
         assert p1 != p2
-        if p1>p2:
+        if p1 > p2:
             pom = p1
             p1 = p2
             p2 = pom
@@ -1079,12 +1079,12 @@ class Diagram():
         point2 = line.p2        
         line.p2 = point
         line.object.refresh_line()
-        l2 = self.join_line(point, point2)        
+        l2 = self.join_line(point, point2)
         #save revert operations to history
         self._history.add_line(line.id, line.p1.id, point2.id, None)
         self._history.delete_line(line.id, None)
         # TODO: case if one line is merged (line between new point and one of line point)
-        # TODO: case if two lines is merged (triangle) 
+        # TODO: case if two lines is merged (triangle)
         
 
         return l2, releasing_lines

--- a/src/LayerEditor/ui/data/polygon_operation.py
+++ b/src/LayerEditor/ui/data/polygon_operation.py
@@ -75,7 +75,7 @@ class PolygonOperation():
         self.decomposition.remove_free_point(point.de_id)
         
     def add_line(self, diagram, line, label=None, not_history=True):
-        """Add new point to decomposition"""
+        """Add new line to decomposition"""
         if self.tmp_line is not None:
             segment = self.decomposition.new_segment(
                 self.decomposition.points[self.tmp_line.p1.de_id], 
@@ -338,7 +338,7 @@ class PolygonOperation():
         diagram.del_polygon(spolygon, label, not_history)
 
     def _split_polygon(self, diagram, polygon_id, polygon_old_id, label, not_history):
-        """split poligon"""
+        """split polygon"""
         self._reload_boundary(diagram, polygon_old_id)
         self._fix_lines(diagram, polygon_id, polygon_old_id)
         self._add_polygon(diagram, polygon_id, label, not_history, polygon_old_id)

--- a/src/LayerEditor/ui/panels/diagram.py
+++ b/src/LayerEditor/ui/panels/diagram.py
@@ -490,26 +490,28 @@ class Diagram(QtWidgets.QGraphicsScene):
                     self._point_moving.point_data.x, self._point_moving.point_data.y))
             cfg.diagram.move_point_after(self._point_moving.point_data,
                 self._point_moving_old.x(), self._point_moving_old.y())
-        elif isinstance(below_item, Line) and len(self._point_moving.point_data.lines) == 1 and not_obstructed:
-            # split line by adding new line and merge the new point with the moving one
-            #TODO: line split to history
-            p, _ = self._add_point(below_item, QtCore.QPointF(
-                self._point_moving.point_data.x, self._point_moving.point_data.y))
-            cfg.diagram.move_point_after(self._point_moving.point_data, self._point_moving_old.x(),
-                                         self._point_moving_old.y(), 'Merge points')
-            removed_lines = cfg.diagram.merge_point(p.point_data, self._point_moving.point_data, None)
-            self._point_moving.release_point()
-            self.remove_graphical_object(self._point_moving)
-            self.update_changes([], [],  [], [], removed_lines)
-            p.move_point(event.scenePos(), ItemStates.standart)
-        elif isinstance(below_item, Point) and len(self._point_moving.point_data.lines) == 1 and not_obstructed:
-            cfg.diagram.move_point_after(self._point_moving.point_data,self._point_moving_old.x(),
-                self._point_moving_old.y(), 'Merge points')
-            removed_lines = cfg.diagram.merge_point(below_item.point_data, self._point_moving.point_data, None)
-            self._point_moving.release_point()
-            self.remove_graphical_object(self._point_moving)
-            self.update_changes([], [],  [], [], removed_lines)
-            below_item.move_point(event.scenePos(), ItemStates.standart)
+        ### The drag2split function is ommited before the line contraction is implemented in the data layer.
+        ### now only dragging is supported, either unobstructed or limited.
+        # elif isinstance(below_item, Line) and len(self._point_moving.point_data.lines) == 1 and not_obstructed:
+        #     # split line by adding new line and merge the new point with the moving one
+        #     #TODO: line split to history
+        #     p, _ = self._add_point(below_item, QtCore.QPointF(
+        #         self._point_moving.point_data.x, self._point_moving.point_data.y))
+        #     cfg.diagram.move_point_after(self._point_moving.point_data, self._point_moving_old.x(),
+        #                                  self._point_moving_old.y(), 'Merge points')
+        #     removed_lines = cfg.diagram.merge_point(p.point_data, self._point_moving.point_data, None)
+        #     self._point_moving.release_point()
+        #     self.remove_graphical_object(self._point_moving)
+        #     self.update_changes([], [],  [], [], removed_lines)
+        #     p.move_point(event.scenePos(), ItemStates.standart)
+        # elif isinstance(below_item, Point) and len(self._point_moving.point_data.lines) == 1 and not_obstructed:
+        #     cfg.diagram.move_point_after(self._point_moving.point_data,self._point_moving_old.x(),
+        #         self._point_moving_old.y(), 'Merge points')
+        #     removed_lines = cfg.diagram.merge_point(below_item.point_data, self._point_moving.point_data, None)
+        #     self._point_moving.release_point()
+        #     self.remove_graphical_object(self._point_moving)
+        #     self.update_changes([], [],  [], [], removed_lines)
+        #     below_item.move_point(event.scenePos(), ItemStates.standart)
         else:
             # Path obstructed
             self._point_moving.move_point(QtCore.QPointF(

--- a/src/LayerEditor/ui/panels/diagram.py
+++ b/src/LayerEditor/ui/panels/diagram.py
@@ -491,22 +491,24 @@ class Diagram(QtWidgets.QGraphicsScene):
             cfg.diagram.move_point_after(self._point_moving.point_data,
                 self._point_moving_old.x(), self._point_moving_old.y())
         elif isinstance(below_item, Line) and len(self._point_moving.point_data.lines) == 1 and not_obstructed:
-            cfg.diagram.move_point_after(self._point_moving.point_data,self._point_moving_old.x(),
-                self._point_moving_old.y(), 'Move point to Line')
-            new_line, merged_lines = cfg.diagram.add_point_to_line(below_item.line_data,
-                self._point_moving.point_data, None)
-            l = Line(new_line)
-            self.add_graphical_object(l)
-            self._point_moving.move_point(QtCore.QPointF(
-                self._point_moving.point_data.x, self._point_moving.point_data.y), ItemStates.standart)
-            self.update_changes([], [],  [], [], merged_lines)
+            # split line by adding new line and merge the new point with the moving one
+            #TODO: line split to history
+            p, _ = self._add_point(below_item, QtCore.QPointF(
+                self._point_moving.point_data.x, self._point_moving.point_data.y))
+            cfg.diagram.move_point_after(self._point_moving.point_data, self._point_moving_old.x(),
+                                         self._point_moving_old.y(), 'Merge points')
+            removed_lines = cfg.diagram.merge_point(p.point_data, self._point_moving.point_data, None)
+            self._point_moving.release_point()
+            self.remove_graphical_object(self._point_moving)
+            self.update_changes([], [],  [], [], removed_lines)
+            p.move_point(event.scenePos(), ItemStates.standart)
         elif isinstance(below_item, Point) and len(self._point_moving.point_data.lines) == 1 and not_obstructed:
             cfg.diagram.move_point_after(self._point_moving.point_data,self._point_moving_old.x(),
                 self._point_moving_old.y(), 'Merge points')
             removed_lines = cfg.diagram.merge_point(below_item.point_data, self._point_moving.point_data, None)
             self._point_moving.release_point()
             self.remove_graphical_object(self._point_moving)
-            self.update_changes([], [],  [], [], removed_lines)            
+            self.update_changes([], [],  [], [], removed_lines)
             below_item.move_point(event.scenePos(), ItemStates.standart)
         else:
             # Path obstructed
@@ -542,7 +544,7 @@ class Diagram(QtWidgets.QGraphicsScene):
             if self._point_moving is not None:
                 # either moving point or clicked on existing one
                 if self._point_moving_counter > 1:
-                    # TODO: take care of cases when point is moving in wrong manner, e.g. creating overlapping lines. This should be taken care of on data layer.
+                    # TODO: take care of cases when point is moving in wrong manner, e.g. creating overlapping lines. This should be taken care of in data layer.
                     # if the point is actually moving in space (mouseMoveEvent occurred)
                     self._anchor_moved_point(event)
                 else:


### PR DESCRIPTION
Refactor moving onto a line. Avoid using many functions in diagram_structures, hopefully allowing the refactorization of the diagram_structures.Diagram object in the future.
resolves #229

Signed-off-by: Martin Matusu <Martin.Matusu@tul.cz>