### PR TITLE
Temporary init area fix until Zoom object is removed and margins are set up correctly

### DIFF
--- a/src/LayerEditor/ui/gitems/init_area.py
+++ b/src/LayerEditor/ui/gitems/init_area.py
@@ -16,11 +16,12 @@ class InitArea(QtWidgets.QGraphicsPolygonItem):
         self.setPen(QtGui.QPen(QtCore.Qt.NoPen))
         brush = QtGui.QBrush(QtGui.QColor(246, 246, 246))
         self.setBrush(brush)
-        self.setZValue(self.STANDART_ZVALUE) 
+        self.setZValue(self.STANDART_ZVALUE)
+        self.reload()
                 
     def reload(self):
         """Reload new init area"""
-        poly = cfg.diagram.get_area_poly(cfg.layers, cfg.diagrams.index(cfg.diagram))
-        self.setPolygon(poly)    
- 
-    
+        bbox = cfg.diagram.get_diagram_all_rect(cfg.diagram.rect, cfg.layers, cfg.diagrams.index(cfg.diagram))
+        poly = QtGui.QPolygonF(bbox)
+        self.setPolygon(poly)
+        cfg.diagram.area.gtpolygon = poly

--- a/src/LayerEditor/ui/mainwindow.py
+++ b/src/LayerEditor/ui/mainwindow.py
@@ -141,17 +141,18 @@ class MainWindow(QtWidgets.QMainWindow):
         cfg.diagram.regions.reload_regions(cfg)
         self.refresh_view_data(0)
         self.update_layers_panel()
+        self._refresh_area()
         if not cfg.diagram.position_set():
-            self.display_area()        
+            self.display_area()
 
     def paint_new_data(self):
         """Propagate new diagram scene to canvas"""
-        self.display_area()
         self.layers.change_size()
         self.diagramScene.show_init_area(True)
         if not cfg.config.show_init_area:
             self.diagramScene.show_init_area(False)            
-        
+        self.display_area()
+
     def refresh_curr_data(self, old_i, new_i):
         """Propagate new diagram scene to canvas"""
         if old_i == new_i:
@@ -302,7 +303,6 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             self.diagramScene.hide_grid()
 
-        
     def _refresh_area(self):
         """Refresh init area"""
         if self.diagramScene.init_area is not None:


### PR DESCRIPTION
A semi-working solution of init area, a proper fix has to be done after zoom removal and especially margins bound to it, which cause inaccuracies in setting up the working area...

Signed-off-by: Martin Matusu <Martin.Matusu@tul.cz>